### PR TITLE
Run minitest via mt, with support for focus, fail-fast, and color

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ require "rubocop/rake_task"
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.libs << "lib"
-  t.test_files = FileList["test/**/*_test.rb"]
+  t.test_files = FileList["test/**/*_test.rb"] - FileList["test/fixtures/**/*"]
 end
 
 RuboCop::RakeTask.new

--- a/lib/mighty_test/cli.rb
+++ b/lib/mighty_test/cli.rb
@@ -13,6 +13,8 @@ module MightyTest
         print_help
       elsif options[:version]
         puts VERSION
+      else
+        run_tests_by_path
       end
     rescue Exception => e # rubocop:disable Lint/RescueException
       handle_exception(e)
@@ -27,6 +29,10 @@ module MightyTest
       puts option_parser.to_s.sub(/^\s*-h.*?\n/, "")
       puts
       runner.print_help_and_exit!
+    end
+
+    def run_tests_by_path
+      runner.run_inline_and_exit!(*path_args, args: extra_args)
     end
 
     def handle_exception(e) # rubocop:disable Naming/MethodParameterName

--- a/lib/mighty_test/minitest_runner.rb
+++ b/lib/mighty_test/minitest_runner.rb
@@ -5,5 +5,18 @@ module MightyTest
       Minitest.run(["--help"])
       exit
     end
+
+    def run_inline_and_exit!(*test_files, args: [])
+      $LOAD_PATH.unshift "test"
+      ARGV.replace(Array(args))
+
+      require "minitest/focus"
+      require "minitest/rg"
+
+      test_files.flatten.each { |file| require File.expand_path(file.to_s) }
+
+      require "minitest/autorun"
+      exit
+    end
   end
 end

--- a/lib/mighty_test/option_parser.rb
+++ b/lib/mighty_test/option_parser.rb
@@ -6,7 +6,7 @@ module MightyTest
       @parser = ::OptionParser.new do |op|
         op.require_exact = true
         op.banner = <<~BANNER
-          Usage: mt
+          Usage: mt <test file>...
 
         BANNER
 

--- a/mighty_test.gemspec
+++ b/mighty_test.gemspec
@@ -27,4 +27,7 @@ Gem::Specification.new do |spec|
 
   # Runtime dependencies
   spec.add_dependency "minitest", "~> 5.15"
+  spec.add_dependency "minitest-fail-fast", "~> 0.1.0"
+  spec.add_dependency "minitest-focus", "~> 1.4"
+  spec.add_dependency "minitest-rg", "~> 5.3"
 end

--- a/test/fixtures/example_project/lib/example.rb
+++ b/test/fixtures/example_project/lib/example.rb
@@ -1,0 +1,3 @@
+module Example
+  autoload :VERSION, "example/version"
+end

--- a/test/fixtures/example_project/lib/example/version.rb
+++ b/test/fixtures/example_project/lib/example/version.rb
@@ -1,0 +1,3 @@
+module Example
+  VERSION = "0.1.0".freeze
+end

--- a/test/fixtures/example_project/test/example_test.rb
+++ b/test/fixtures/example_project/test/example_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ExampleTest < Minitest::Test
+  def test_that_it_has_a_version_number
+    refute_nil ::Example::VERSION
+  end
+end

--- a/test/fixtures/example_project/test/failing_test.rb
+++ b/test/fixtures/example_project/test/failing_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class FailingTest < Minitest::Test
+  def test_assertion_fails
+    assert_equal "foo", "bar"
+  end
+end

--- a/test/fixtures/example_project/test/focused_test.rb
+++ b/test/fixtures/example_project/test/focused_test.rb
@@ -1,0 +1,11 @@
+require "test_helper"
+
+class FocusedTest < Minitest::Test
+  focus def test_this_test_is_run
+    assert true # rubocop:disable Minitest/UselessAssertion
+  end
+
+  def test_this_test_is_not_run
+    refute true # rubocop:disable Minitest/UselessAssertion
+  end
+end

--- a/test/fixtures/example_project/test/test_helper.rb
+++ b/test/fixtures/example_project/test/test_helper.rb
@@ -1,0 +1,4 @@
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+require "example"
+
+require "minitest/autorun"

--- a/test/integration/mt_test.rb
+++ b/test/integration/mt_test.rb
@@ -8,6 +8,37 @@ module MightyTest
       assert_equal(VERSION, result.stdout.chomp)
     end
 
+    def test_mt_runs_a_successful_test
+      project_dir = File.expand_path("../fixtures/example_project", __dir__)
+      result = bundle_exec_mt(argv: ["test/example_test.rb"], chdir: project_dir)
+
+      assert_match(/Run options:.* --seed \d+/, result.stdout)
+      assert_match(/Finished/, result.stdout)
+      assert_match(/\d runs, \d assertions, 0 failures, 0 errors/, result.stdout)
+    end
+
+    def test_mt_runs_a_failing_test_and_exits_with_non_zero_status
+      project_dir = File.expand_path("../fixtures/example_project", __dir__)
+      result = bundle_exec_mt(argv: ["test/failing_test.rb"], chdir: project_dir, raise_on_failure: false)
+
+      assert_predicate(result, :failure?)
+      assert_match(/\d runs, \d assertions, 1 failures, 0 errors/, result.stdout)
+    end
+
+    def test_mt_supports_test_focus
+      project_dir = File.expand_path("../fixtures/example_project", __dir__)
+      result = bundle_exec_mt(argv: ["test/focused_test.rb"], chdir: project_dir)
+
+      assert_match(/1 runs, 1 assertions, 0 failures, 0 errors/, result.stdout)
+    end
+
+    def test_mt_passes_fail_fast_flag_to_minitest
+      project_dir = File.expand_path("../fixtures/example_project", __dir__)
+      result = bundle_exec_mt(argv: ["--fail-fast", "test/example_test.rb"], chdir: project_dir)
+
+      assert_match(/Run options:.* --fail-fast/, result.stdout)
+    end
+
     private
 
     def bundle_exec_mt(argv:, env: { "CI" => nil }, chdir: nil, raise_on_failure: true)
@@ -15,8 +46,9 @@ module MightyTest
         system(env, *%w[bundle exec mt] + argv, { chdir: }.compact)
       end
 
-      result = CLIResult.new(stdout, stderr, Process.last_status.exitstatus)
-      raise "mt exited with status: #{exitstatus}" if raise_on_failure && result.failure?
+      exitstatus = Process.last_status.exitstatus
+      result = CLIResult.new(stdout, stderr, exitstatus)
+      raise "mt exited with status: #{exitstatus} and output: #{stdout + stderr}" if raise_on_failure && result.failure?
 
       result
     end


### PR DESCRIPTION
Running Minitest tests is a matter of `require`-ing each test file, then loading `minitest/autorun` followed by `exit`. This commit wires up this logic to the `mt` executable, allowing arbitrary test files to be run via the CLI.

I've also added `minitest-rg`, `minitest-focus`, and `minitest-fail-fast` as runtime dependencies. This enables a bunch of useful behavior when running tests.