### PR TITLE
Add keyboard commands to watch mode

### DIFF
--- a/lib/mighty_test/console.rb
+++ b/lib/mighty_test/console.rb
@@ -2,7 +2,8 @@ require "io/console"
 
 module MightyTest
   class Console
-    def initialize(sound_player: "/usr/bin/afplay", sound_paths: SOUNDS)
+    def initialize(stdin: $stdin, sound_player: "/usr/bin/afplay", sound_paths: SOUNDS)
+      @stdin = stdin
       @sound_player = sound_player
       @sound_paths = sound_paths
     end
@@ -12,6 +13,12 @@ module MightyTest
 
       $stdout.clear_screen
       true
+    end
+
+    def wait_for_keypress
+      return stdin.getc unless stdin.respond_to?(:raw)
+
+      stdin.raw(intr: true) { stdin.getc }
     end
 
     def play_sound(name, wait: false)
@@ -42,7 +49,7 @@ module MightyTest
     private_constant :SOUNDS
     # rubocop:enable Layout/LineLength
 
-    attr_reader :sound_player, :sound_paths
+    attr_reader :sound_player, :sound_paths, :stdin
 
     def tty?
       $stdout.respond_to?(:tty?) && $stdout.tty?

--- a/test/mighty_test/console_test.rb
+++ b/test/mighty_test/console_test.rb
@@ -20,6 +20,12 @@ module MightyTest
       assert_equal "clear!", stdout
     end
 
+    def test_wait_for_keypress_returns_the_next_character_on_stdin
+      console = Console.new(stdin: StringIO.new("hi"))
+
+      assert_equal "h", console.wait_for_keypress
+    end
+
     def test_play_sound_returns_false_if_not_tty
       result = nil
       capture_io { result = Console.new.play_sound(:pass) }


### PR DESCRIPTION
This commit makes watch mode interactive. It now understands these keys:

- Press ENTER to run all tests
- Press "q" to quit

To do this, I start another background thread that listens for key presses. When a key is pressed, the thread posts a `:keypress` event to the event loop. The event loop then takes an appropriate action.

Because they keypress listener is running in a thread separate from the file system listener, that means the watcher is still able to detect changes to files and auto-run tests. The event loop funnels all of these events into a single thread of execution.