### PR TITLE
Ensure watcher is properly terminated in integration test

### DIFF
--- a/test/integration/mt_test.rb
+++ b/test/integration/mt_test.rb
@@ -71,7 +71,7 @@ module MightyTest
         sleep 1
 
         # OK, we're done here. Tell mt --watch to exit.
-        Process.kill(:INT, pid)
+        Process.kill(:TERM, pid)
       end
 
       assert_includes(stdout, "Watching for changes to source and test files.")


### PR DESCRIPTION
This fixes a bug where the terminal would sometimes get stuck in raw mode after running the mt integration tests.