### PR TITLE
Ensure watch (d)iff command finds staged files

### DIFF
--- a/lib/mighty_test/file_system.rb
+++ b/lib/mighty_test/file_system.rb
@@ -27,10 +27,13 @@ module MightyTest
     end
 
     def find_new_and_changed_paths
-      out, _err, status = Open3.capture3(*%w[git ls-files --deduplicate -m -o --exclude-standard test app lib])
+      out, _err, status = Open3.capture3(*%w[git status --porcelain=1 -uall -z --no-renames -- test app lib])
       return [] unless status.success?
 
-      out.lines(chomp: true).reject(&:empty?).uniq
+      out
+        .split("\x0")
+        .filter_map { |line| line[/^.. (.+)/, 1] }
+        .uniq
     rescue SystemCallError
       []
     end

--- a/test/mighty_test/file_system_test.rb
+++ b/test/mighty_test/file_system_test.rb
@@ -115,10 +115,13 @@ module MightyTest
     end
 
     def test_find_new_and_changed_paths_returns_array_based_on_git_output
-      git_output = <<~OUT
-        lib/mighty_test/file_system.rb
-        test/mighty_test/file_system_test.rb
-      OUT
+      git_output = [
+        "M  lib/mighty_test/cli.rb",
+        " M lib/mighty_test/file_system.rb",
+        "M  lib/mighty_test/sharder.rb",
+        " M test/mighty_test/file_system_test.rb",
+        "?? test/mighty_test/sharder_test.rb"
+      ].join("\x0")
 
       status = Minitest::Mock.new
       status.expect(:success?, true)
@@ -129,8 +132,11 @@ module MightyTest
 
       assert_equal(
         %w[
+          lib/mighty_test/cli.rb
           lib/mighty_test/file_system.rb
+          lib/mighty_test/sharder.rb
           test/mighty_test/file_system_test.rb
+          test/mighty_test/sharder_test.rb
         ],
         paths
       )


### PR DESCRIPTION
Previously, when "d" was pressed in watch mode, we were using `git ls-files` to find the list of new and modified files. If a file was modified but staged/cached (i.e. it was added with `git add` but not yet committed), it would not be detected.

This commit changes the diff implementation to use `git status` instead, which lists both staged and un-staged changes.