### PR TITLE
Handle Minitest flags that accept values, like `--seed`

### DIFF
--- a/lib/mighty_test/option_parser.rb
+++ b/lib/mighty_test/option_parser.rb
@@ -1,54 +1,49 @@
-require "optparse"
+require "shellwords"
 
 module MightyTest
   class OptionParser
-    def initialize # rubocop:disable Metrics/AbcSize
-      @parser = ::OptionParser.new do |op|
-        op.require_exact = true
-        op.banner = <<~BANNER
-          Usage: mt [--all]
-                 mt [test file...] [test dir...]
-                 mt --watch
-
-        BANNER
-
-        op.on("--all") { options[:all] = true }
-        op.on("--watch") { options[:watch] = true }
-        op.on("--shard SHARD") { |value| options[:shard] = value }
-        op.on("-h", "--help") { options[:help] = true }
-        op.on("--version") { options[:version] = true }
-      end
-    end
-
     def parse(argv)
-      @options = {}
-      done = false
-      extra_args = []
       argv, literal_args = split(argv, "--")
+      options = parse_options!(argv)
+      minitest_flags = parse_minitest_flags!(argv) unless options[:help]
 
-      until done
-        orig_argv = argv.dup
-        begin
-          parser.parse!(argv)
-          done = true
-        rescue ::OptionParser::InvalidOption => e
-          invalid = e.args.first
-          extra_args << invalid
-          orig_argv.delete_at(orig_argv.index(invalid))
-          argv = orig_argv
-        end
-      end
-
-      [argv + literal_args, extra_args, options]
+      [argv + literal_args, minitest_flags || [], options]
     end
 
     def to_s
-      parser.to_s
+      <<~USAGE
+        Usage: mt [--all]
+               mt [test file...] [test dir...]
+               mt --watch
+      USAGE
     end
 
     private
 
-    attr_reader :options, :parser
+    def parse_options!(argv)
+      options = {}
+      options[:all] = true if argv.delete("--all")
+      options[:watch] = true if argv.delete("--watch")
+      options[:version] = true if argv.delete("--version")
+      options[:help] = true if argv.delete("--help") || argv.delete("-h")
+      parse_shard(argv, options)
+      options
+    end
+
+    def parse_minitest_flags!(argv)
+      return [] if argv.grep(/\A-/).none?
+
+      require "minitest"
+      orig_argv = argv.dup
+
+      Minitest.load_plugins unless argv.delete("--no-plugins") || ENV["MT_NO_PLUGINS"]
+      minitest_options = Minitest.process_args(argv)
+
+      minitest_args = Shellwords.split(minitest_options[:args] || "")
+      remove_seed_flag(minitest_args) unless orig_argv.include?("--seed")
+
+      minitest_args
+    end
 
     def split(array, delim)
       delim_at = array.index(delim)
@@ -58,6 +53,25 @@ module MightyTest
         array[0...delim_at],
         array[(delim_at + 1)..]
       ]
+    end
+
+    def parse_shard(argv, options)
+      argv.delete_if { |arg| options[:shard] = Regexp.last_match(1) if arg =~ /\A--shard=(.*)/ }
+
+      argv.each_with_index do |flag, i|
+        value = argv[i + 1]
+        next unless flag == "--shard"
+        raise "missing shard value" if value.nil? || value.start_with?("-")
+
+        options[:shard] = value
+        argv.slice!(i, 2)
+        break
+      end
+    end
+
+    def remove_seed_flag(parsed_argv)
+      index = parsed_argv.index("--seed")
+      parsed_argv.slice!(index, 2) if index
     end
   end
 end

--- a/test/mighty_test/option_parser_test.rb
+++ b/test/mighty_test/option_parser_test.rb
@@ -15,21 +15,68 @@ module MightyTest
       )
     end
 
+    def test_doesnt_return_seed_args_if_they_werent_specified
+      argv = %w[-f]
+      _path_args, extra_args, _options = OptionParser.new.parse(argv)
+
+      assert_equal %w[-f], extra_args
+    end
+
     def test_dash_v_is_not_considered_an_abbreviation_of_version
       argv = ["-v"]
       _path_args, extra_args, options = OptionParser.new.parse(argv)
 
       assert_empty(options)
-      assert_equal(["-v"], extra_args)
+      assert_includes(extra_args, "-v")
     end
 
-    def test_handles_mix_of_recognized_and_unrecognized_flags_and_args
-      argv = %w[path1 --other path2 --help path3 -X -- path4 --great]
+    def test_shard_value_can_be_specified_with_equals_sign
+      argv = %w[--shard=1/2]
+      path_args, extra_args, options = OptionParser.new.parse(argv)
+
+      assert_empty(path_args)
+      assert_empty(extra_args)
+      assert_equal("1/2", options[:shard])
+    end
+
+    def test_shard_value_can_be_specified_without_equals_sign
+      argv = %w[--shard 1/2]
+      path_args, extra_args, options = OptionParser.new.parse(argv)
+
+      assert_empty(path_args)
+      assert_empty(extra_args)
+      assert_equal("1/2", options[:shard])
+    end
+
+    def test_places_minitest_seed_option_into_extra_args
+      argv = %w[--seed 1234]
+      path_args, extra_args, = OptionParser.new.parse(argv)
+
+      assert_empty(path_args)
+      assert_equal(%w[--seed 1234], extra_args)
+    end
+
+    def test_handles_mix_of_mt_and_minitest_flags_and_args
+      argv = %w[path1 --seed 1234 path2 --shard 1/2 path3 -f --all -- path4 --great]
       path_args, extra_args, options = OptionParser.new.parse(argv)
 
       assert_equal(%w[path1 path2 path3 path4 --great], path_args)
-      assert_equal(%w[--other -X], extra_args)
-      assert_equal({ help: true }, options)
+      assert_equal(%w[--seed 1234 -f], extra_args)
+      assert_equal({ all: true, shard: "1/2" }, options)
+    end
+
+    def test_exits_with_failing_status_on_unrecognized_flag
+      argv = %w[--non-existent]
+      exitstatus = nil
+
+      stdout, = capture_io do
+        OptionParser.new.parse(argv)
+      rescue SystemExit => e
+        exitstatus = e.status
+      end
+
+      assert_equal 1, exitstatus
+      assert_includes(stdout, "invalid option: --non-existent")
     end
   end
 end


### PR DESCRIPTION
mighty_test needs an option parser to handle its own flags, like `--all`, `--shard`, and `--watch`. However, users can also pass in Minitest flags like `--seed` or `--fail-fast` and expect them to be passed to Minitest when tests are run.

This is challenging, because the full range of flags that Minitest supports isn't known in advanced. Minitest plugins can add arbitrary flags as runtime. Therefore we can't write a single option parser that works for mighty_test and Minitest.

The implementation in this commit takes the following approach: First, parse the flags that mighty_test understands, like `--all`. Then check if there are any unrecognized flags remaining. If so, use Minitest's internal `process_args` method to parse the remaining flags.

The result isn't perfect (Minitest's error handling does a hard exit when it encounters at invalid option, so we don't have an opportunity to format or augment the help message), but it works for common cases.

I removed `optparse` because its design assumes a single parser that handles the entirety of ARGV. We need a parser that can decode flags one at a time, and then pass the remainder to Minitest, something that I couldn't get to work with `optparse`.

I decided to "brute force" the parsing of the few flags that mighty_test understands, rather than pull in a third-party gem.