### PR TITLE
Remove concurrent-ruby dependency

### DIFF
--- a/lib/mighty_test/watcher.rb
+++ b/lib/mighty_test/watcher.rb
@@ -1,11 +1,9 @@
-require "concurrent"
-
 module MightyTest
   class Watcher
     WATCHING_FOR_CHANGES = 'Watching for changes to source and test files. Press "q" to quit.'.freeze
 
     def initialize(console: Console.new, extra_args: [], file_system: FileSystem.new, system_proc: method(:system))
-      @event = Concurrent::MVar.new
+      @queue = Thread::Queue.new
       @console = console
       @extra_args = extra_args
       @file_system = file_system
@@ -111,11 +109,11 @@ module MightyTest
 
     def await_next_event
       file_system_listener.start if file_system_listener.paused?
-      @event.take
+      @queue.pop
     end
 
     def post_event(*event)
-      @event.put(event)
+      @queue << event
     end
   end
 end

--- a/mighty_test.gemspec
+++ b/mighty_test.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Runtime dependencies
-  spec.add_dependency "concurrent-ruby", "~> 1.1"
   spec.add_dependency "listen", "~> 3.5"
   spec.add_dependency "minitest", "~> 5.15"
   spec.add_dependency "minitest-fail-fast", "~> 0.1.0"


### PR DESCRIPTION
Replace `Concurrent::MVar` with Ruby's built-in `Thread::Queue`.