### PR TITLE
Show watcher help menu when "h" key is pressed

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,10 +169,10 @@ Watch mode also offers a menu of interactive commands:
 
 ```
 > Press Enter to run all tests.
-> Press a to run all tests, including slow tests.
-> Press d to run tests for files diffed or added since the last git commit.
-> Press h to show this help menu.
-> Press q to quit.
+> Press "a" to run all tests, including slow tests.
+> Press "d" to run tests for files diffed or added since the last git commit.
+> Press "h" to show this help menu.
+> Press "q" to quit.
 ```
 
 ## 🔬 Focus Mode

--- a/lib/mighty_test/watcher.rb
+++ b/lib/mighty_test/watcher.rb
@@ -1,6 +1,6 @@
 module MightyTest
-  class Watcher
-    WATCHING_FOR_CHANGES = 'Watching for changes to source and test files. Press "q" to quit.'.freeze
+  class Watcher # rubocop:disable Metrics/ClassLength
+    WATCHING_FOR_CHANGES = 'Watching for changes to source and test files. Press "h" for help or "q" to quit.'.freeze
 
     def initialize(console: Console.new, extra_args: [], file_system: FileSystem.new, system_proc: method(:system))
       @queue = Thread::Queue.new
@@ -10,7 +10,7 @@ module MightyTest
       @system_proc = system_proc
     end
 
-    def run(iterations: :indefinitely) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength
+    def run(iterations: :indefinitely) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
       start_file_system_listener
       start_keypress_listener
       puts WATCHING_FOR_CHANGES
@@ -25,6 +25,8 @@ module MightyTest
           run_all_tests(flags: ["--all"])
         in [:keypress, "d"]
           run_matching_test_files_from_git_diff
+        in [:keypress, "h"]
+          show_help
         in [:keypress, "q"]
           break
         else
@@ -40,6 +42,24 @@ module MightyTest
     private
 
     attr_reader :console, :extra_args, :file_system, :file_system_listener, :keypress_listener, :system_proc
+
+    def show_help
+      console.clear
+      puts <<~MENU
+        `mt --watch` is watching file system activity and will automatically run
+        test files when they are added or modified. If you modify a source file,
+        mt will find and run the corresponding tests.
+
+        You can also trigger test runs with the following interactive commands.
+
+        > Press Enter to run all tests.
+        > Press "a" to run all tests, including slow tests.
+        > Press "d" to run tests for files diffed or added since the last git commit.
+        > Press "h" to show this help menu.
+        > Press "q" to quit.
+
+      MENU
+    end
 
     def run_all_tests(flags: [])
       console.clear

--- a/test/mighty_test/watcher_test.rb
+++ b/test/mighty_test/watcher_test.rb
@@ -68,7 +68,7 @@ module MightyTest
         [SYSTEM] mt -- test/example_test.rb
         [SOUND] :pass
 
-        Watching for changes to source and test files. Press "q" to quit.
+        Watching for changes to source and test files. Press "h" for help or "q" to quit.
       EXPECTED
     end
 
@@ -87,7 +87,7 @@ module MightyTest
         [SYSTEM] mt -- test/example_test.rb
         [SOUND] :fail
 
-        Watching for changes to source and test files. Press "q" to quit.
+        Watching for changes to source and test files. Press "h" for help or "q" to quit.
       EXPECTED
     end
 
@@ -172,7 +172,19 @@ module MightyTest
       assert_includes(stdout, <<~EXPECTED)
         [CLEAR]
         No affected test files detected since the last git commit.
-        Watching for changes to source and test files. Press "q" to quit.
+        Watching for changes to source and test files. Press "h" for help or "q" to quit.
+      EXPECTED
+    end
+
+    def test_watcher_shows_help_menu_when_h_key_is_pressed
+      stdout, = run_watcher(stdin: "hq", in: fixtures_path.join("example_project"))
+
+      assert_includes(stdout, <<~EXPECTED)
+        > Press Enter to run all tests.
+        > Press "a" to run all tests, including slow tests.
+        > Press "d" to run tests for files diffed or added since the last git commit.
+        > Press "h" to show this help menu.
+        > Press "q" to quit.
       EXPECTED
     end
 


### PR DESCRIPTION
Pressing "h" while the watch command is running will now display this help message and menu:

```
`mt --watch` is watching file system activity and will automatically run
test files when they are added or modified. If you modify a source file,
mt will find and run the corresponding tests.

You can also trigger test runs with the following interactive commands.

> Press Enter to run all tests.
> Press "a" to run all tests, including slow tests.
> Press "d" to run tests for files diffed or added since the last git commit.
> Press "h" to show this help menu.
> Press "q" to quit.
```