### PR TITLE
Allow use of interactive debugger when running tests in watch mode

### DIFF
--- a/lib/mighty_test/console.rb
+++ b/lib/mighty_test/console.rb
@@ -16,9 +16,10 @@ module MightyTest
     end
 
     def wait_for_keypress
-      return stdin.getc unless stdin.respond_to?(:raw) && tty?
-
-      stdin.raw(intr: true) { stdin.getc }
+      with_raw_input do
+        sleep if stdin.eof?
+        stdin.getc
+      end
     end
 
     def play_sound(name, wait: false)
@@ -53,6 +54,12 @@ module MightyTest
 
     def tty?
       $stdout.respond_to?(:tty?) && $stdout.tty?
+    end
+
+    def with_raw_input(&)
+      return yield unless stdin.respond_to?(:raw) && tty?
+
+      stdin.raw(intr: true, &)
     end
   end
 end


### PR DESCRIPTION
Before, `mt --watch` would take full control of stdin to listen for keyboard commands. This prevented the use of an interactive debugger when a test is being executed.

This PR changes the event loop implementation so that control of stdin is relinquished when running tests. This allows an interactive debugger to be used while tests are running.

Specifically:

- Move stdin reader (i.e. `$stdin.getc`) out of a background thread and into the main event loop.
- `$stdin.getc` blocks until a character is typed.
- When the file system listener background thread detects a change, raise an exception in the main event loop to break out of `$stdin.getc` and proceed to run the tests.