### PR TITLE
Fix failing test due to listen gem warning on Ruby 3.4

### DIFF
--- a/test/integration/mt_test.rb
+++ b/test/integration/mt_test.rb
@@ -74,8 +74,11 @@ module MightyTest
         Process.kill(:TERM, pid)
       end
 
-      assert_includes(stdout, "Watching for changes to source and test files.")
+      # Ignore warning printed to stderr for a known issue with the listen gem
+      stderr.sub!(/^.*\blisten\.rb.*Add logger to your Gemfile or gemspec\.\n/, "")
       assert_empty(stderr)
+
+      assert_includes(stdout, "Watching for changes to source and test files.")
       assert_match(/ExampleTest/, stdout)
       assert_match(/\d runs, \d assertions, 0 failures, 0 errors/, stdout)
     end


### PR DESCRIPTION
The `listen` gem has an undeclared dependency on `logger`, which causes a warning to be printed in Ruby 3.4:

> listen-3.9.0/lib/listen.rb:3: warning: logger was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.5.0. Add logger to your Gemfile or gemspec.

This causes one of our integration tests to fail, because we expect no warnings to be printed when running `mt`.

This needs to be fixed upstream in the `listen` gem (a PR is already open: https://github.com/guard/listen/pull/581). For now, work around the problem by ignoring this particular warning.