### PR TITLE
Watcher: Defer FS listener restart to fix Ruby 3.4.0.dev crash

### DIFF
--- a/lib/mighty_test/watcher.rb
+++ b/lib/mighty_test/watcher.rb
@@ -109,7 +109,8 @@ module MightyTest
       $stdout.flush
     rescue Interrupt
       # Pressing ctrl-c kills the fs_event background process, so we have to manually restart it.
-      restart_file_system_listener
+      # Do this in a separate thread to work around odd behavior on Ruby 3.4.
+      Thread.new { restart_file_system_listener }
     end
 
     def start_file_system_listener


### PR DESCRIPTION
This fixes the `test_watcher_restarts_the_listener_when_a_test_run_is_interrupted` test that started failing recently on the latest builds of ruby-head. Something internal to Ruby's threading/exception handling model has apparently changed. 

Deferring restarting the listener thread until the Interrupt exception has fully propagated seems to fix the issue.