### PR TITLE
Add logger dependency to fix Ruby 3.4 warnings

### DIFF
--- a/mighty_test.gemspec
+++ b/mighty_test.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
 
   # Runtime dependencies
   spec.add_dependency "listen", "~> 3.5"
+  spec.add_dependency "logger"
   spec.add_dependency "minitest", "~> 5.15"
   spec.add_dependency "minitest-fail-fast", "~> 0.1.0"
   spec.add_dependency "minitest-focus", "~> 1.4"


### PR DESCRIPTION
The `listen` gem depends on `logger`, but does not properly declare it as a gem dependency. This results in the following warning when using `mt --watch` on Ruby 3.4:

> listen-3.9.0/lib/listen.rb:3: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add logger to your Gemfile or gemspec to silence this warning.

Since `listen` does not seem to be actively maintained, I am adding the `logger` dependency to mighty_test as a workaround.